### PR TITLE
Make API compatible with Python 3.10

### DIFF
--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -18,7 +18,7 @@ __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
            "unix_dialect"]
 
 
-def escape(payload):
+def _escape(payload):
     if payload is None:
         return ''
     if isinstance(payload, Number):
@@ -41,10 +41,10 @@ class _ProxyWriter:
         except TypeError as err:
             msg = "iterable expected, not %s" % type(row).__name__
             raise Error(msg) from err
-        return self.writer.writerow([escape(field) for field in row])
+        return self.writer.writerow([_escape(field) for field in row])
 
     def writerows(self, rows):
-        return self.writer.writerows([[escape(field) for field in row] for row in rows])
+        return self.writer.writerows([[_escape(field) for field in row] for row in rows])
 
     def __getattr__(self, item):
         return getattr(self.writer, item)

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -4,12 +4,17 @@ from csv import (
     DictReader, DictWriter as BaseDictWriter, Error, Sniffer, excel, excel_tab,
     field_size_limit, get_dialect, list_dialects, reader, register_dialect,
     unix_dialect, unregister_dialect, writer as basewriter,
+    __doc__,
 )
 
+from . import version as __version__
+
 __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
-           "Error", "Dialect", "excel", "excel_tab", "field_size_limit", "reader", "writer",
+           "Error", "Dialect", "__doc__", "excel", "excel_tab",
+           "field_size_limit", "reader", "writer",
            "register_dialect", "get_dialect", "list_dialects", "Sniffer",
-           "unregister_dialect", "DictReader", "DictWriter", "unix_dialect"]
+           "unregister_dialect", "__version__", "DictReader", "DictWriter",
+           "unix_dialect"]
 
 
 def escape(payload):

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -6,6 +6,7 @@ from csv import (
     unix_dialect, unregister_dialect, writer as _basewriter,
     __doc__,
 )
+from numbers import Number
 
 from . import version as __version__
 
@@ -20,6 +21,8 @@ __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
 def escape(payload):
     if payload is None:
         return ''
+    if isinstance(payload, Number):
+        return payload
 
     payload = str(payload)
     if payload and payload[0] in ('@', '+', '-', '=', '|', '%') and not re.match("^-?[0-9,\\.]+$", payload):
@@ -33,10 +36,10 @@ class _ProxyWriter:
         self.writer = writer
 
     def writerow(self, row):
-        self.writer.writerow([escape(field) for field in row])
+        return self.writer.writerow([escape(field) for field in row])
 
     def writerows(self, rows):
-        self.writer.writerows([[escape(field) for field in row] for row in rows])
+        return self.writer.writerows([[escape(field) for field in row] for row in rows])
 
     def __getattr__(self, item):
         return getattr(self.writer, item)

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -1,9 +1,9 @@
 import re
 from csv import (
     QUOTE_ALL, QUOTE_MINIMAL, QUOTE_NONE, QUOTE_NONNUMERIC, Dialect,
-    DictReader, DictWriter as BaseDictWriter, Error, Sniffer, excel, excel_tab,
+    DictReader, DictWriter as _BaseDictWriter, Error, Sniffer, excel, excel_tab,
     field_size_limit, get_dialect, list_dialects, reader, register_dialect,
-    unix_dialect, unregister_dialect, writer as basewriter,
+    unix_dialect, unregister_dialect, writer as _basewriter,
     __doc__,
 )
 
@@ -28,7 +28,7 @@ def escape(payload):
     return payload
 
 
-class ProxyWriter:
+class _ProxyWriter:
     def __init__(self, writer):
         self.writer = writer
 
@@ -43,10 +43,10 @@ class ProxyWriter:
 
 
 def writer(csvfile, dialect='excel', **fmtparams):
-    return ProxyWriter(basewriter(csvfile, dialect, **fmtparams))
+    return _ProxyWriter(_basewriter(csvfile, dialect, **fmtparams))
 
 
-class DictWriter(BaseDictWriter):
+class DictWriter(_BaseDictWriter):
     def __init__(self, f, fieldnames, restval="", extrasaction="raise",
                  dialect="excel", *args, **kwds):
         super().__init__(f, fieldnames, restval, extrasaction, dialect, *args, **kwds)

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -36,6 +36,11 @@ class _ProxyWriter:
         self.writer = writer
 
     def writerow(self, row):
+        try:
+            iter(row)
+        except TypeError as err:
+            msg = "iterable expected, not %s" % type(row).__name__
+            raise Error(msg) from err
         return self.writer.writerow([escape(field) for field in row])
 
     def writerows(self, rows):

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -1,5 +1,5 @@
 import pytest
-from defusedcsv.csv import escape
+from defusedcsv.csv import _escape as escape
 
 
 @pytest.mark.parametrize("input,expected", [

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -44,9 +44,14 @@ def test_dangerous_sample_payloads(input, expected):
     "Test | Foo",
     "",
     None,
+])
+def test_safe_sample_payloads(input):
+    assert escape(input) == (str(input) if input is not None else '')
+
+@pytest.mark.parametrize("input", [
     1,
     2,
     True
 ])
-def test_safe_sample_payloads(input):
-    assert escape(input) == (str(input) if input is not None else '')
+def test_safe_nonstr_sample_payloads(input):
+    assert escape(input) == input

--- a/tests/test_unmodified.py
+++ b/tests/test_unmodified.py
@@ -32,6 +32,9 @@ def test_has_attributes():
     assert hasattr(csv, 'QUOTE_NONNUMERIC')
     assert hasattr(csv, 'QUOTE_NONE')
     assert hasattr(csv, 'Error')
+    assert hasattr(csv, 'writer')
+    assert hasattr(csv, '__doc__')
+    assert hasattr(csv, '__version__')
 
 
 def test_dialect_registry():


### PR DESCRIPTION
This PR brings defusedcsv in line with the [Python 3.10 std lib csv library](https://docs.python.org/3.10/library/csv.html) as closely as possible. This was accomplished by copying the contents of [`test_csv.py` from the 3.10 branch](https://github.com/python/cpython/blob/89192c46da7b984811ff3bd648f8e827e4ef053c/Lib/test/test_csv.py) into the `tests/` folder, changing the `import csv` import to `from defusedcsv import csv` and running the tests with:

```bash
py.test tests
```

The following changes were motivated by those test results:

- Synchronize the `__all__` attribute with [`csv.__all__`](https://github.com/python/cpython/blob/ccac6312b9f9d8209646c85492920962fb5704ba/Lib/csv.py#L16-L21).
- Mark classes that don't appear in `__all__` as private by prefixing them with `_`.
- `_escape()` returns payloads unchanged if they are an instance of [`Number`](https://docs.python.org/3.10/library/numbers.html#numbers.Number) in order to preserve the behavior of [`QUOTE_NONNUMERIC`](https://docs.python.org/3.10/library/csv.html#csv.QUOTE_NONNUMERIC).
- `_ProxyWriter.writerow` and `_ProxyWriter.writerows` now include return statements.
- `_ProxyWriter.writerow` raises `csv.Error` if the `row` argument is not iterable.

More details and reference links can be found in the commit messages. Of course, I'm happy to make changes as requested.

Fixes #5