### PR TITLE
README: Fix OWASP link, add labels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ This library acts as a drop-in replacement for the standard library's ``csv`` mo
 Useful Links
 ------------
 
-* https://www.owasp.org/index.php/CSV_Excel_Macro_Injection
-* https://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
-* https://blog.zsec.uk/csv-dangers-mitigations/
+* `CSV Injection Software Attack | OWASP Foundation <https://owasp.org/www-community/attacks/CSV_Injection>`_
+* `Comma Separated Vulnerabilities | Context Information Security <https://www.contextis.com/resources/blog/comma-separated-vulnerabilities/>`_
+* `CSV Injection Mitigations & Dangers | ZeroSec - Adventures In Information Security <https://blog.zsec.uk/csv-dangers-mitigations/>`_
 
 License
 -------


### PR DESCRIPTION
The OWASP URL went to a 404, I've replaced it with an equivalent that works.

Also added labels for each link corresponding to their page title for better accessibility (see [Understanding Success Criterion 2.4.4: Link Purpose (In Context)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)).