### PR TITLE
Make API compatible with Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ This library tries to mitigate that by prepending all cells starting with ``@``,
 ``|`` characters in these cells with ``\|``. This will of course change the resulting
 CSV files, but Excel will not display the ``'`` character to the user.
 
-Tested with Python 3.8 to 3.13.
+Tested with Python 3.9 to 3.13.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ This library tries to mitigate that by prepending all cells starting with ``@``,
 ``|`` characters in these cells with ``\|``. This will of course change the resulting
 CSV files, but Excel will not display the ``'`` character to the user.
 
-Tested with Python 3.8 to 3.10.
+Tested with Python 3.8 to 3.13.
 
 Usage
 -----

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -9,8 +9,16 @@ from numbers import Number
 
 from . import version as __version__
 
+try:
+    # Requires Python >= 3.12
+    from csv import QUOTE_NOTNULL, QUOTE_STRINGS  # noqa: F401
+    _py312_constants = ["QUOTE_NOTNULL", "QUOTE_STRINGS"]
+except ImportError:
+    _py312_constants = []
+
+
 __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
-           "Error", "Dialect", "__doc__", "excel", "excel_tab",
+           *_py312_constants, "Error", "Dialect", "__doc__", "excel", "excel_tab",
            "field_size_limit", "reader", "writer",
            "register_dialect", "get_dialect", "list_dialects", "Sniffer",
            "unregister_dialect", "__version__", "DictReader", "DictWriter",

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -27,7 +27,7 @@ __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
 
 def _escape(payload):
     if payload is None:
-        return ''
+        return payload
     if isinstance(payload, Number):
         return payload
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 
     keywords='csv injection defuse save',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Other Audience',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -47,7 +47,7 @@ def test_dangerous_sample_payloads(input, expected):
     None,
 ])
 def test_safe_sample_payloads(input):
-    assert escape(input) == (str(input) if input is not None else '')
+    assert escape(input) == input
 
 
 @pytest.mark.parametrize("input", [


### PR DESCRIPTION
This PR makes some changes to ensure defusedcsv is fully API-compatible with the [csv module since Python 3.13](https://docs.python.org/3.13/library/csv.html).

The process was similar to #6:

1. Copy the [CPython `/Lib/test/test_csv.py`](https://github.com/python/cpython/blob/22d729cf5db6b03930d52c648327e0d953f9e3bc/Lib/test/test_csv.py) file into the `tests` folder.
3. Replace `import csv` with `from defusedcsv import csv`.
4. In `MiscTestCase.test__all__`, add `'defusedcsv.csv'` to the tuple being passed to the `name_of_module` argument of the `support.check__all__` function.
5. Run the tests with:

   ```shell
   py.test tests
   ```

6. All tests should pass, except:

   ```
   FAILED tests/test_csv.py::MiscTestCase::test__all__ - AssertionError: Element counts were not equal:
   First has 1, Second has 0:  '__doc__'
   First has 1, Second has 0:  '__version__'
   ```

Changes:

1. Added [`csv.QUOTE_NOTNULL`](https://docs.python.org/3.13/library/csv.html#csv.QUOTE_NOTNULL) and [`csv.QUOTE_STRINGS`](https://docs.python.org/3.13/library/csv.html#csv.QUOTE_STRINGS) constants if they are importable (Python 3.12 and newer).
2. Changed `_escape()` to return `payload` if `payload` is `None`, rather than an empty string. This allowed a test to pass.
3. Declare support for Python ~~3.8~~ 3.9 to 3.13.