### PR TITLE
Replace list comprehensions with generators

### DIFF
--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -48,10 +48,10 @@ class _ProxyWriter:
         except TypeError as err:
             msg = "iterable expected, not %s" % type(row).__name__
             raise Error(msg) from err
-        return self.writer.writerow([_escape(field) for field in row])
+        return self.writer.writerow(_escape(field) for field in row)
 
     def writerows(self, rows):
-        return self.writer.writerows([[_escape(field) for field in row] for row in rows])
+        return self.writer.writerows((_escape(field) for field in row) for row in rows)
 
     def __getattr__(self, item):
         return getattr(self.writer, item)


### PR DESCRIPTION
By using [generator expressions][0] in `_ProxyWriter.writerow` and `_ProxyWriter.writerows` instead of [list comprehensions][1], those methods can avoid loading the entire row or iterable of rows into memory at once, reducing peak memory consumption.

No unit tests were written due to the difficulty in asserting the behavior we're looking for.

Fixes #10

[0]: https://docs.python.org/3/glossary.html#term-generator-expression
[1]: https://docs.python.org/3/glossary.html#term-list-comprehension

## Manual testing

On macOS, you can check the peak memory usage of the module with this test script:

```python
"""
test_mem.py

Write a lot of CSV rows to stdout.
"""
import random
import sys

from defusedcsv import csv


def rows():
    return (iter(str(random.random()) for _ in range(50)) for _ in range(10_000))


if __name__ == "__main__":
    writer = csv.writer(sys.stdout)
    writer.writerows(rows())
```

And running it like this:

```shell
/usr/bin/time -l python test_mem.py 2>&1 > out.csv | grep 'peak memory footprint'
```

On the `master` branch I get ~45 MB, but with this PR I only get ~8 MB.