### PR TITLE
Add type hints

### DIFF
--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 import re
 from csv import (
@@ -30,10 +30,8 @@ __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
            "unregister_dialect", "__version__", "DictReader", "DictWriter",
            "unix_dialect"]
 
-T = TypeVar("T")
 
-
-def _escape(payload: T) -> "None | Number | str":
+def _escape(payload: Any) -> "None | Number | str":
     if payload is None:
         return payload
     if isinstance(payload, Number):

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -65,7 +65,7 @@ class _ProxyWriter:
         return getattr(self.writer, item)
 
 
-def writer(csvfile: "io.TextIOBase", dialect='excel', **fmtparams):
+def writer(csvfile: "io.TextIOBase", /, dialect='excel', **fmtparams):
     return _ProxyWriter(_basewriter(csvfile, dialect, **fmtparams))
 
 

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -56,7 +56,7 @@ class _ProxyWriter:
             raise Error(msg) from err
         return self.writer.writerow(_escape(field) for field in row)
 
-    def writerows(self, rows: "Iterable[Iterable[Any]]"):
+    def writerows(self, rows: "Iterable[Iterable[Any]]") -> None:
         return self.writer.writerows((_escape(field) for field in row) for row in rows)
 
     def __getattr__(self, item: str):

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -33,7 +33,7 @@ __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
 T = TypeVar("T")
 
 
-def _escape(payload: T) -> None | Number | str:
+def _escape(payload: T) -> "None | Number | str":
     if payload is None:
         return payload
     if isinstance(payload, Number):

--- a/defusedcsv/csv.py
+++ b/defusedcsv/csv.py
@@ -39,11 +39,11 @@ def _escape(payload: T) -> None | Number | str:
     if isinstance(payload, Number):
         return payload
 
-    payload = str(payload)
-    if payload and payload[0] in ('@', '+', '-', '=', '|', '%') and not re.match("^-?[0-9,\\.]+$", payload):
-        payload = payload.replace("|", "\\|")
-        payload = "'" + payload
-    return payload
+    str_payload = str(payload)
+    if str_payload and str_payload[0] in ('@', '+', '-', '=', '|', '%') and not re.match("^-?[0-9,\\.]+$", str_payload):
+        str_payload = str_payload.replace("|", "\\|")
+        str_payload = "'" + str_payload
+    return str_payload
 
 
 class _ProxyWriter:


### PR DESCRIPTION
- Add [type hints](https://docs.python.org/3/library/typing.html) to function arguments.
- `_escape`: Avoid reassigning the type of `payload` for better code intelligence.
- `writer`: Add [positional argument delimiter `/`](https://peps.python.org/pep-0570/) after `csvfile` to match [`csv.writer`](https://docs.python.org/3/library/csv.html#csv.writer).